### PR TITLE
Handle non-ASCII URLs & Minor improvements on image filenames

### DIFF
--- a/bbid/bbid.py
+++ b/bbid/bbid.py
@@ -85,7 +85,7 @@ def download(pool_sema: threading.Semaphore, img_sema: threading.Semaphore, url:
                 print('SKIP: Already downloaded ' + filename + ', not saving')
                 return
             i += 1
-            filename = "%s-%d%s" % (name, i, ext)
+            filename = "%s-%d.%s" % (name, i, ext)
 
         image_md5s[md5_key] = filename
 


### PR DESCRIPTION

Changes

- Generate a filename when a basename is an empty string
  - The basename of `path` of an URL can be an empty string (e.g. `http://sample.domain/abcd/?query` => path is `abcd/` and basename is an empty string).
  - In such cases, the downloader generates a filename with the md5 hash value of a full URL.

- Generate a file extension from the image content
  - Instead of using the last dot-separated part (which may contain an arbitrary string ) or a default value (`.gif`), the downloader infers a file extension from the image content.

- Handle non-ASCII URLs
  - Implemented a naive URL encoding function so that the downloader can download from URLs with non-ASCII characters.
 